### PR TITLE
Attempt To fix Prod Deploy

### DIFF
--- a/src/api/routes/index.ts
+++ b/src/api/routes/index.ts
@@ -19,8 +19,8 @@ export * from "./lookup-tables-router";
 
 const router = Router();
 
-router.use(checkJwt);
-router.use(loadUser);
+router.use("/api", checkJwt);
+router.use("/api", loadUser);
 
 // TODO: move all routing logic to this file, and move all route actions into controllers
 router.route("/api/forms").post(FormsController.create);


### PR DESCRIPTION
# Context

![image](https://github.com/ytgov/travel-authorization/assets/23045206/f69e27be-8ae5-48e3-8acb-5175f360f380)

:beetle: Avoid clobbering all routes with jwt auth, and only lock down `/api` ones.