### PR TITLE
Fixup: Migration Pipeline

### DIFF
--- a/api/bin/boot-app.sh
+++ b/api/bin/boot-app.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # Run migrations
-npm run knex migrate:latest
+./node_modules/.bin/knex --knexfile ./dist/config.d/knexfile.js migrate:latest
 
 initialization_status=$?
 if [ $initialization_status -ne 0 ]; then

--- a/api/src/data/migrations/20231016203328_rename-destinations-to-locations.ts
+++ b/api/src/data/migrations/20231016203328_rename-destinations-to-locations.ts
@@ -2,13 +2,13 @@ import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
   await knex.schema.renameTable("destinations", "locations")
-  await knex.schema.table("locations", (table) => {
+  await knex.schema.alterTable("locations", (table) => {
     table.timestamps(true, true)
   })
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("locations", (table) => {
+  await knex.schema.alterTable("locations", (table) => {
     table.dropColumn("created_at")
     table.dropColumn("updated_at")
   })

--- a/api/src/data/migrations/20231016233127_snake-case-columns-in-expenses-table.ts
+++ b/api/src/data/migrations/20231016233127_snake-case-columns-in-expenses-table.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("expenses", (table) => {
+  await knex.schema.alterTable("expenses", (table) => {
     table.renameColumn("receiptImage", "receipt_image")
     table.renameColumn("fileSize", "file_size")
     table.renameColumn("fileName", "file_name")
@@ -10,7 +10,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("expenses", (table) => {
+  await knex.schema.alterTable("expenses", (table) => {
     table.renameColumn("receipt_image", "receiptImage")
     table.renameColumn("file_size", "fileSize")
     table.renameColumn("file_name", "fileName")

--- a/api/src/data/migrations/20231016233128_fix-foreign-key-reference-to-forms-table-in-expenses-table.ts
+++ b/api/src/data/migrations/20231016233128_fix-foreign-key-reference-to-forms-table-in-expenses-table.ts
@@ -1,14 +1,14 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("expenses", (table) => {
+  await knex.schema.alterTable("expenses", (table) => {
     table.renameColumn("taid", "form_id")
     table.foreign("form_id").references("id").inTable("forms").onDelete("CASCADE")
   })
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("expenses", (table) => {
+  await knex.schema.alterTable("expenses", (table) => {
     table.dropForeign("form_id")
     table.renameColumn("form_id", "taid")
   })

--- a/api/src/data/migrations/20231016233129_add-timestamp-columns-to-expenses-table.ts
+++ b/api/src/data/migrations/20231016233129_add-timestamp-columns-to-expenses-table.ts
@@ -1,13 +1,13 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("expenses", (table) => {
+  await knex.schema.alterTable("expenses", (table) => {
     table.timestamps(true, true)
   })
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("expenses", (table) => {
+  await knex.schema.alterTable("expenses", (table) => {
     table.dropColumn("created_at")
     table.dropColumn("updated_at")
   })

--- a/api/src/data/migrations/20231017175009_drop-deprecated-purpose-column-from-travel-authorizations-table.ts
+++ b/api/src/data/migrations/20231017175009_drop-deprecated-purpose-column-from-travel-authorizations-table.ts
@@ -1,13 +1,13 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_authorizations", (table) => {
+  await knex.schema.alterTable("travel_authorizations", (table) => {
     table.dropColumn("purpose")
   })
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_authorizations", (table) => {
+  await knex.schema.alterTable("travel_authorizations", (table) => {
     table.string("purpose", 255).nullable()
   })
 }

--- a/api/src/data/migrations/20231017220512_underscore-all-travel-authorization-column-names.ts
+++ b/api/src/data/migrations/20231017220512_underscore-all-travel-authorization-column-names.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  return knex.schema.table("travel_authorizations", (table) => {
+  return knex.schema.alterTable("travel_authorizations", (table) => {
     table.renameColumn("formId", "form_id")
     table.renameColumn("preappId", "preapp_id")
     table.renameColumn("purposeId", "purpose_id")
@@ -25,7 +25,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema.table("travel_authorizations", (table) => {
+  return knex.schema.alterTable("travel_authorizations", (table) => {
     table.renameColumn("form_id", "formId")
     table.renameColumn("preapp_id", "preappId")
     table.renameColumn("purpose_id", "purposeId")

--- a/api/src/data/migrations/20231017221732_rename-form-id-to-slug-on-travel-authorization.ts
+++ b/api/src/data/migrations/20231017221732_rename-form-id-to-slug-on-travel-authorization.ts
@@ -2,14 +2,14 @@ import { Knex } from "knex";
 
 
 export async function up(knex: Knex): Promise<void> {
-  return knex.schema.table("travel_authorizations", (table) => {
+  return knex.schema.alterTable("travel_authorizations", (table) => {
     table.renameColumn("form_id", "slug")
   })
 }
 
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema.table("travel_authorizations", (table) => {
+  return knex.schema.alterTable("travel_authorizations", (table) => {
     table.renameColumn("slug", "form_id")
   })
 }

--- a/api/src/data/migrations/20231017222703_add-timestampt-columns-to-travel-authorizations-table.ts
+++ b/api/src/data/migrations/20231017222703_add-timestampt-columns-to-travel-authorizations-table.ts
@@ -1,13 +1,13 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_authorizations", (table) => {
+  await knex.schema.alterTable("travel_authorizations", (table) => {
     table.timestamps(true, true)
   })
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_authorizations", (table) => {
+  await knex.schema.alterTable("travel_authorizations", (table) => {
     table.dropColumn("created_at")
     table.dropColumn("updated_at")
   })

--- a/api/src/data/migrations/20231017223028_standardize-expenses-foreign-key-reference-to-travel-authorizations-table.ts
+++ b/api/src/data/migrations/20231017223028_standardize-expenses-foreign-key-reference-to-travel-authorizations-table.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("expenses", (table) => {
+  await knex.schema.alterTable("expenses", (table) => {
     table.dropForeign(["form_id"])
 
     table.renameColumn("form_id", "travel_authorization_id")
@@ -15,7 +15,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("expenses", (table) => {
+  await knex.schema.alterTable("expenses", (table) => {
     table.dropForeign(["travel_authorization_id"])
 
     table.renameColumn("travel_authorization_id", "form_id")

--- a/api/src/data/migrations/20231017223028_standardize-expenses-foreign-key-reference-to-travel-authorizations-table.ts
+++ b/api/src/data/migrations/20231017223028_standardize-expenses-foreign-key-reference-to-travel-authorizations-table.ts
@@ -20,6 +20,6 @@ export async function down(knex: Knex): Promise<void> {
 
     table.renameColumn("travel_authorization_id", "form_id")
 
-    table.foreign("form_id").references("id").inTable("forms").onDelete("CASCADE")
+    table.foreign("form_id").references("id").inTable("travel_authorizations").onDelete("CASCADE")
   })
 }

--- a/api/src/data/migrations/20231017232537_convert-stops-table-columns-to-snake-case.ts
+++ b/api/src/data/migrations/20231017232537_convert-stops-table-columns-to-snake-case.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("stops", (table) => {
+  await knex.schema.alterTable("stops", (table) => {
     table.renameColumn("taid", "ta_id")
     table.renameColumn("locationId", "location_id")
     table.renameColumn("departureDate", "departure_date")
@@ -11,7 +11,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("stops", (table) => {
+  await knex.schema.alterTable("stops", (table) => {
     table.renameColumn("ta_id", "taid")
     table.renameColumn("location_id", "locationId")
     table.renameColumn("departure_date", "departureDate")

--- a/api/src/data/migrations/20231018003340_standardize-taid-foreign-key-in-stops-table.ts
+++ b/api/src/data/migrations/20231018003340_standardize-taid-foreign-key-in-stops-table.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("stops", (table) => {
+  await knex.schema.alterTable("stops", (table) => {
     table.renameColumn("ta_id", "travel_authorization_id")
     table
       .foreign("travel_authorization_id")
@@ -12,7 +12,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("stops", (table) => {
+  await knex.schema.alterTable("stops", (table) => {
     table.dropForeign("travel_authorization_id")
     table.renameColumn("travel_authorization_id", "ta_id")
   })

--- a/api/src/data/migrations/20231018005434_add-timestamp-columns-to-stops-table.ts
+++ b/api/src/data/migrations/20231018005434_add-timestamp-columns-to-stops-table.ts
@@ -2,13 +2,13 @@ import { Knex } from "knex";
 
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("stops", (table) => {
+  await knex.schema.alterTable("stops", (table) => {
     table.timestamps(true, true)
   })
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("stops", (table) => {
+  await knex.schema.alterTable("stops", (table) => {
     table.dropColumn("created_at")
     table.dropColumn("updated_at")
   })

--- a/api/src/data/migrations/20231018220003_rename-name-in-travel-desk-npr-documents-table.ts
+++ b/api/src/data/migrations/20231018220003_rename-name-in-travel-desk-npr-documents-table.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travelDeskPnrDocuments", async (table) => {
+  await knex.schema.alterTable("travelDeskPnrDocuments", async (table) => {
     table.dropPrimary()
     table.dropForeign(["requestID"])
   })
@@ -11,7 +11,7 @@ export async function up(knex: Knex): Promise<void> {
     "travel_desk_passenger_name_record_documents"
   )
 
-  await knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", async (table) => {
     table.primary(["documentID"])
     table
       .foreign("requestID")
@@ -26,7 +26,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", async (table) => {
     table.dropPrimary()
     table.dropForeign(["requestID"])
   })
@@ -36,7 +36,7 @@ export async function down(knex: Knex): Promise<void> {
     "travelDeskPnrDocuments"
   )
 
-  await knex.schema.table("travelDeskPnrDocuments", async (table) => {
+  await knex.schema.alterTable("travelDeskPnrDocuments", async (table) => {
     table.primary(["documentID"])
     table
       .foreign("requestID")

--- a/api/src/data/migrations/20231018220004_standardize-primary-key-name-in-travel-desk-npr-documents-table.ts
+++ b/api/src/data/migrations/20231018220004_standardize-primary-key-name-in-travel-desk-npr-documents-table.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", async (table) => {
     table.dropPrimary()
     table.renameColumn("documentID", "id")
     table.primary(["id"])
@@ -13,7 +13,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", async (table) => {
     table.dropPrimary()
     table.renameColumn("id", "documentID")
     table.primary(["documentID"])

--- a/api/src/data/migrations/20231018220005_snake-case-all-travel-desk-pnr-documents-columns.ts
+++ b/api/src/data/migrations/20231018220005_snake-case-all-travel-desk-pnr-documents-columns.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  return knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+  return knex.schema.alterTable("travel_desk_passenger_name_record_documents", async (table) => {
     table.dropForeign(["requestID"])
     table.renameColumn("requestID", "travel_desk_travel_request_id")
     table
@@ -16,7 +16,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  return knex.schema.table("travel_desk_passenger_name_record_documents", async (table) => {
+  return knex.schema.alterTable("travel_desk_passenger_name_record_documents", async (table) => {
     table.dropForeign(["travel_desk_travel_request_id"])
     table.renameColumn("travel_desk_travel_request_id", "requestID")
     table

--- a/api/src/data/migrations/20231018233031_add-timestamp-columns-to-travel-desk-passenger-name-record-document-table.ts
+++ b/api/src/data/migrations/20231018233031_add-timestamp-columns-to-travel-desk-passenger-name-record-document-table.ts
@@ -2,13 +2,13 @@ import { Knex } from "knex";
 
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table.timestamps(true, true)
   })
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table.dropColumn("created_at")
     table.dropColumn("updated_at")
   })

--- a/api/src/data/migrations/20231019171610_standardize-travel-desk-travel-request-table-name.ts
+++ b/api/src/data/migrations/20231019171610_standardize-travel-desk-travel-request-table-name.ts
@@ -1,22 +1,22 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travelDeskFlightRequest", (table) => {
+  await knex.schema.alterTable("travelDeskFlightRequest", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskRentalCar", (table) => {
+  await knex.schema.alterTable("travelDeskRentalCar", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskHotel", (table) => {
+  await knex.schema.alterTable("travelDeskHotel", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskOtherTransportation", (table) => {
+  await knex.schema.alterTable("travelDeskOtherTransportation", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskQuestion", (table) => {
+  await knex.schema.alterTable("travelDeskQuestion", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table.dropForeign(
       ["travel_desk_travel_request_id"],
       "travel_desk_pnr_documents_travel_desk_travel_request_id_foreign"
@@ -24,7 +24,7 @@ export async function up(knex: Knex): Promise<void> {
   })
 
   // START: Core table changes
-  await knex.schema.table("travelDeskTravelRequest", async (table) => {
+  await knex.schema.alterTable("travelDeskTravelRequest", async (table) => {
     table.dropPrimary()
     table.dropForeign(["TAID"])
     table.dropForeign(["agencyID"])
@@ -32,7 +32,7 @@ export async function up(knex: Knex): Promise<void> {
 
   await knex.schema.renameTable("travelDeskTravelRequest", "travel_desk_travel_requests")
 
-  await knex.schema.table("travel_desk_travel_requests", async (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", async (table) => {
     table.primary(["requestID"])
     table.foreign("TAID").references("id").inTable("travel_authorizations").onDelete("CASCADE")
     table
@@ -47,42 +47,42 @@ export async function up(knex: Knex): Promise<void> {
   )
   // END: Core table changes
 
-  await knex.schema.table("travelDeskFlightRequest", (table) => {
+  await knex.schema.alterTable("travelDeskFlightRequest", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskRentalCar", (table) => {
+  await knex.schema.alterTable("travelDeskRentalCar", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskHotel", (table) => {
+  await knex.schema.alterTable("travelDeskHotel", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskOtherTransportation", (table) => {
+  await knex.schema.alterTable("travelDeskOtherTransportation", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskQuestion", (table) => {
+  await knex.schema.alterTable("travelDeskQuestion", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table
       .foreign(
         "travel_desk_travel_request_id",
@@ -95,22 +95,22 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travelDeskFlightRequest", (table) => {
+  await knex.schema.alterTable("travelDeskFlightRequest", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskRentalCar", (table) => {
+  await knex.schema.alterTable("travelDeskRentalCar", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskHotel", (table) => {
+  await knex.schema.alterTable("travelDeskHotel", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskOtherTransportation", (table) => {
+  await knex.schema.alterTable("travelDeskOtherTransportation", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskQuestion", (table) => {
+  await knex.schema.alterTable("travelDeskQuestion", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table.dropForeign(
       ["travel_desk_travel_request_id"],
       "travel_desk_pnr_documents_travel_desk_travel_request_id_foreign"
@@ -118,7 +118,7 @@ export async function down(knex: Knex): Promise<void> {
   })
 
   // START: Core table changes
-  await knex.schema.table("travel_desk_travel_requests", async (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", async (table) => {
     table.dropPrimary()
     table.dropForeign(["TAID"])
     table.dropForeign(["agencyID"])
@@ -126,7 +126,7 @@ export async function down(knex: Knex): Promise<void> {
 
   await knex.schema.renameTable("travel_desk_travel_requests", "travelDeskTravelRequest")
 
-  await knex.schema.table("travelDeskTravelRequest", async (table) => {
+  await knex.schema.alterTable("travelDeskTravelRequest", async (table) => {
     table.primary(["requestID"])
     table.foreign("TAID").references("id").inTable("travel_authorizations").onDelete("CASCADE")
     table
@@ -141,42 +141,42 @@ export async function down(knex: Knex): Promise<void> {
   )
   // END: Core table changes
 
-  await knex.schema.table("travelDeskFlightRequest", (table) => {
+  await knex.schema.alterTable("travelDeskFlightRequest", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travelDeskTravelRequest")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskRentalCar", (table) => {
+  await knex.schema.alterTable("travelDeskRentalCar", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travelDeskTravelRequest")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskHotel", (table) => {
+  await knex.schema.alterTable("travelDeskHotel", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travelDeskTravelRequest")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskOtherTransportation", (table) => {
+  await knex.schema.alterTable("travelDeskOtherTransportation", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travelDeskTravelRequest")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskQuestion", (table) => {
+  await knex.schema.alterTable("travelDeskQuestion", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travelDeskTravelRequest")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table
       .foreign(
         "travel_desk_travel_request_id",

--- a/api/src/data/migrations/20231019174706_standardize-primary-key-name-in-travel-desk-travel-request-table.ts
+++ b/api/src/data/migrations/20231019174706_standardize-primary-key-name-in-travel-desk-travel-request-table.ts
@@ -1,22 +1,22 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travelDeskFlightRequest", (table) => {
+  await knex.schema.alterTable("travelDeskFlightRequest", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskRentalCar", (table) => {
+  await knex.schema.alterTable("travelDeskRentalCar", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskHotel", (table) => {
+  await knex.schema.alterTable("travelDeskHotel", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskOtherTransportation", (table) => {
+  await knex.schema.alterTable("travelDeskOtherTransportation", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskQuestion", (table) => {
+  await knex.schema.alterTable("travelDeskQuestion", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table.dropForeign(
       ["travel_desk_travel_request_id"],
       "travel_desk_pnr_documents_travel_desk_travel_request_id_foreign"
@@ -24,7 +24,7 @@ export async function up(knex: Knex): Promise<void> {
   })
 
   // START: Core table changes
-  await knex.schema.table("travel_desk_travel_requests", async (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", async (table) => {
     table.dropPrimary()
     table.renameColumn("requestID", "id")
     table.primary(["id"])
@@ -34,42 +34,42 @@ export async function up(knex: Knex): Promise<void> {
   )
   // END: Core table changes
 
-  await knex.schema.table("travelDeskFlightRequest", (table) => {
+  await knex.schema.alterTable("travelDeskFlightRequest", (table) => {
     table
       .foreign("requestID")
       .references("id")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskRentalCar", (table) => {
+  await knex.schema.alterTable("travelDeskRentalCar", (table) => {
     table
       .foreign("requestID")
       .references("id")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskHotel", (table) => {
+  await knex.schema.alterTable("travelDeskHotel", (table) => {
     table
       .foreign("requestID")
       .references("id")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskOtherTransportation", (table) => {
+  await knex.schema.alterTable("travelDeskOtherTransportation", (table) => {
     table
       .foreign("requestID")
       .references("id")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskQuestion", (table) => {
+  await knex.schema.alterTable("travelDeskQuestion", (table) => {
     table
       .foreign("requestID")
       .references("id")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table
       .foreign(
         "travel_desk_travel_request_id",
@@ -82,22 +82,22 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travelDeskFlightRequest", (table) => {
+  await knex.schema.alterTable("travelDeskFlightRequest", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskRentalCar", (table) => {
+  await knex.schema.alterTable("travelDeskRentalCar", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskHotel", (table) => {
+  await knex.schema.alterTable("travelDeskHotel", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskOtherTransportation", (table) => {
+  await knex.schema.alterTable("travelDeskOtherTransportation", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travelDeskQuestion", (table) => {
+  await knex.schema.alterTable("travelDeskQuestion", (table) => {
     table.dropForeign(["requestID"])
   })
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table.dropForeign(
       ["travel_desk_travel_request_id"],
       "travel_desk_pnr_documents_travel_desk_travel_request_id_foreign"
@@ -105,7 +105,7 @@ export async function down(knex: Knex): Promise<void> {
   })
 
   // START: Core table changes
-  await knex.schema.table("travel_desk_travel_requests", async (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", async (table) => {
     table.dropPrimary()
     table.renameColumn("id", "requestID")
     table.primary(["requestID"])
@@ -115,42 +115,42 @@ export async function down(knex: Knex): Promise<void> {
   )
   // END: Core table changes
 
-  await knex.schema.table("travelDeskFlightRequest", (table) => {
+  await knex.schema.alterTable("travelDeskFlightRequest", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskRentalCar", (table) => {
+  await knex.schema.alterTable("travelDeskRentalCar", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskHotel", (table) => {
+  await knex.schema.alterTable("travelDeskHotel", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskOtherTransportation", (table) => {
+  await knex.schema.alterTable("travelDeskOtherTransportation", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travelDeskQuestion", (table) => {
+  await knex.schema.alterTable("travelDeskQuestion", (table) => {
     table
       .foreign("requestID")
       .references("requestID")
       .inTable("travel_desk_travel_requests")
       .onDelete("CASCADE")
   })
-  await knex.schema.table("travel_desk_passenger_name_record_documents", (table) => {
+  await knex.schema.alterTable("travel_desk_passenger_name_record_documents", (table) => {
     table
       .foreign(
         "travel_desk_travel_request_id",

--- a/api/src/data/migrations/20231019181547_standardize-taid-column-foreign-key-in-travel-desk-travel-request-table.ts
+++ b/api/src/data/migrations/20231019181547_standardize-taid-column-foreign-key-in-travel-desk-travel-request-table.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_travel_requests", async (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", async (table) => {
     table.dropForeign(["TAID"])
     table.renameColumn("TAID", "travel_authorization_id")
     table
@@ -13,7 +13,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_travel_requests", async (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", async (table) => {
     table.dropForeign(["travel_authorization_id"])
     table.renameColumn("travel_authorization_id", "TAID")
     table.foreign("TAID").references("id").inTable("travel_authorizations").onDelete("CASCADE")

--- a/api/src/data/migrations/20231019181548_standardize-agency-id-column-foreign-key-in-travel-desk-travel-request-table.ts
+++ b/api/src/data/migrations/20231019181548_standardize-agency-id-column-foreign-key-in-travel-desk-travel-request-table.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_travel_requests", async (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", async (table) => {
     table.dropForeign(["agencyID"])
     table.renameColumn("agencyID", "travel_desk_travel_agent_id")
     table
@@ -13,7 +13,7 @@ export async function up(knex: Knex): Promise<void> {
 }
 
 export async function down(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_travel_requests", async (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", async (table) => {
     table.dropForeign(["travel_desk_travel_agent_id"])
     table.renameColumn("travel_desk_travel_agent_id", "agencyID")
     table

--- a/api/src/data/migrations/20231019205920_add-timestamp-columns-to-travel-desk-travel-request-table.ts
+++ b/api/src/data/migrations/20231019205920_add-timestamp-columns-to-travel-desk-travel-request-table.ts
@@ -1,7 +1,7 @@
 import { Knex } from "knex"
 
 export async function up(knex: Knex): Promise<void> {
-  await knex.schema.table("travel_desk_travel_requests", (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", (table) => {
     table.timestamps(true, true)
   })
 
@@ -10,7 +10,7 @@ export async function up(knex: Knex): Promise<void> {
       SET created_at = submit_date
   `)
 
-  await knex.schema.table("travel_desk_travel_requests", (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", (table) => {
     table.dropColumn("submit_date")
   })
 }
@@ -25,7 +25,7 @@ export async function down(knex: Knex): Promise<void> {
       SET submit_date = created_at
   `)
 
-  await knex.schema.table("travel_desk_travel_requests", (table) => {
+  await knex.schema.alterTable("travel_desk_travel_requests", (table) => {
     table.dropColumn("created_at")
     table.dropColumn("updated_at")
   })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - db_data:/var/lib/postgresql/data
+      - db_data_production:/var/lib/postgresql/data
   web:
     build: .
     restart: unless-stopped
@@ -24,4 +24,4 @@ services:
       - "${HOST_PORT:-8088}:3000"
 
 volumes:
-  db_data:
+  db_data_production:


### PR DESCRIPTION
# Context

There were several dependent problems ocurring.
1. Migrations were failing to run in production causing the app to hang on boot.
2. Code was working fine in local build of production system, but failing in production environment.

# Solution 1

1. Run production version of knex instead of development version.
2. Switch to using alterTable instead of table, because we are on knex 1.0.4.
3. Must rename existing migrations to names ending in `*.js` instead of `*.ts`.
    ```sql
    UPDATE knex_migrations
    SET name = LEFT(name, LENGTH(name) - 3) || '.js'
    WHERE name LIKE '%.ts';
    ```
4. Migrations ran in batches don't reload the database schema between runs, so knex attempts to run migrations for the schema for tables that don't exist until previous migrations have run. The solution to this is to run each migration one at a time. 
    i.e.
    ```sh
    count=1
    while [ $count -le 27 ]
    do
      ./node_modules/.bin/knex --knexfile ./dist/config.d/knexfile.js migrate:up
      count=$((count+1))
    done
    ```
    Depending on whether this becomes a recurring issue, we might want to switch to a `knex.migrate.list() --> each  knex.migrate.up()` strategy. Or switch to using Sequelize + umzug, which doesn't have this problem, for migrations.

# Solution 2

1. Use different names for the development and production database container volumes. Another solution, maybe a more standard one, would be using `travel_development`, `travel_production`, `travel_test` as database names. I'm pretty sure this is what Rails does?