### PR TITLE
Debugging: Temporarily Disable Migration Pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,4 +67,6 @@ EXPOSE 3000
 COPY --from=api-build-stage --chown=node:node /usr/src/api/bin/boot-app.sh ./bin/
 RUN chmod +x ./bin/boot-app.sh
 
-CMD ["./bin/boot-app.sh"]
+# TODO: fix boot pipeline so migrations can auto-run properly
+# CMD ["./bin/boot-app.sh"]
+CMD ["node", "./dist/index.js"]


### PR DESCRIPTION
# Context

The migration automation pipeline is crashing, and the container won't boot.
Temporarily disabling migration pipeline.