### PR TITLE
Upgrade: Knex v1 to Knex v3

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -21,7 +21,7 @@
         "express-validator": "^6.14.2",
         "helmet": "^4.1.1",
         "jwks-rsa": "^3.0.0",
-        "knex": "^1.0.4",
+        "knex": "^3.0.1",
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "mssql": "^6.4.1",
@@ -1638,9 +1638,9 @@
       }
     },
     "node_modules/colorette": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1657,6 +1657,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
       "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -3466,12 +3467,12 @@
       }
     },
     "node_modules/knex": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.7.tgz",
-      "integrity": "sha512-89jxuRATt4qJMb9ZyyaKBy0pQ4d5h7eOFRqiNFnUvsgU+9WZ2eIaZKrAPG1+F3mgu5UloPUnkVE5Yo2sKZUs6Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.0.1.tgz",
+      "integrity": "sha512-ruASxC6xPyDklRdrcDy6a9iqK+R9cGK214aiQa+D9gX2ZnHZKv6o6JC9ZfgxILxVAul4bZ13c3tgOAHSuQ7/9g==",
       "dependencies": {
-        "colorette": "2.0.16",
-        "commander": "^9.1.0",
+        "colorette": "2.0.19",
+        "commander": "^10.0.0",
         "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
@@ -3479,7 +3480,7 @@
         "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
-        "pg-connection-string": "2.5.0",
+        "pg-connection-string": "2.6.1",
         "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
         "tarn": "^3.0.2",
@@ -3489,12 +3490,9 @@
         "knex": "bin/cli.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16"
       },
       "peerDependenciesMeta": {
-        "@vscode/sqlite3": {
-          "optional": true
-        },
         "better-sqlite3": {
           "optional": true
         },
@@ -3510,9 +3508,20 @@
         "pg-native": {
           "optional": true
         },
+        "sqlite3": {
+          "optional": true
+        },
         "tedious": {
           "optional": true
         }
+      }
+    },
+    "node_modules/knex/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/knex/node_modules/debug": {
@@ -4588,9 +4597,9 @@
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
+      "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg=="
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -7476,9 +7485,9 @@
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
     },
     "colorette": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -7491,7 +7500,8 @@
     "commander": {
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
-      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
@@ -8829,12 +8839,12 @@
       }
     },
     "knex": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-1.0.7.tgz",
-      "integrity": "sha512-89jxuRATt4qJMb9ZyyaKBy0pQ4d5h7eOFRqiNFnUvsgU+9WZ2eIaZKrAPG1+F3mgu5UloPUnkVE5Yo2sKZUs6Q==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.0.1.tgz",
+      "integrity": "sha512-ruASxC6xPyDklRdrcDy6a9iqK+R9cGK214aiQa+D9gX2ZnHZKv6o6JC9ZfgxILxVAul4bZ13c3tgOAHSuQ7/9g==",
       "requires": {
-        "colorette": "2.0.16",
-        "commander": "^9.1.0",
+        "colorette": "2.0.19",
+        "commander": "^10.0.0",
         "debug": "4.3.4",
         "escalade": "^3.1.1",
         "esm": "^3.2.25",
@@ -8842,13 +8852,18 @@
         "getopts": "2.3.0",
         "interpret": "^2.2.0",
         "lodash": "^4.17.21",
-        "pg-connection-string": "2.5.0",
+        "pg-connection-string": "2.6.1",
         "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
         "tarn": "^3.0.2",
         "tildify": "2.0.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+        },
         "debug": {
           "version": "4.3.4",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -9680,9 +9695,9 @@
       "optional": true
     },
     "pg-connection-string": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
-      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.1.tgz",
+      "integrity": "sha512-w6ZzNu6oMmIzEAYVw+RLK0+nqHPt8K3ZnknKi+g48Ak2pr3dtljJW3o+D/n2zzCG07Zoe9VOX3aiKpj+BN0pjg=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/api/package.json
+++ b/api/package.json
@@ -24,7 +24,7 @@
     "express-validator": "^6.14.2",
     "helmet": "^4.1.1",
     "jwks-rsa": "^3.0.0",
-    "knex": "^1.0.4",
+    "knex": "^3.0.1",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "mssql": "^6.4.1",


### PR DESCRIPTION
# Context

We are having some problems with migrations, and I upgraded Knex to see if that fixes the issue.

# Solution
:arrow_up: Upgrade knex version to latest (3.0.1)
Apparently doesn't have any breaking changes, see https://github.com/knex/knex/blob/3.0.1/UPGRADING.md

# Testing Instructions

1. Boot the app with `dev up`
2. Check that you can log in at http://localhost:8080/
3. Navigate around and check that everything loads correctly.