### PR TITLE
Fixup: Fix Front-End Build Mode to `production`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# State 0 - base node customizations
+# Stage 0 - base node customizations
 FROM node:16-alpine3.15 as base-node
 
 RUN npm install -g npm@8.5.5
@@ -18,7 +18,7 @@ COPY api ./
 
 RUN npm run build
 
-# State 2 - web build
+# Stage 2 - web build
 FROM base-node as web-build-stage
 
 ENV NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ COPY api ./
 
 RUN npm run build
 
-# State 2 - web build - requires development environment because typescript
+# State 2 - web build
 FROM base-node as web-build-stage
 
-ENV NODE_ENV=development
+ENV NODE_ENV=production
 
 WORKDIR /usr/src/web
 
@@ -32,7 +32,7 @@ RUN npm install
 
 COPY web ./
 
-RUN npm run build:docker
+RUN npm run build
 
 # Stage 3 - production setup
 FROM base-node

--- a/manifests/dev/deployment.yaml
+++ b/manifests/dev/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: travel-authorization-dev
     spec:
       containers:
-        - image: harbor.ynet.gov.yk.ca/yg-github/ytgov/travel-authorization:v2023.10.13.1
+        - image: harbor.ynet.gov.yk.ca/yg-github/ytgov/travel-authorization:v2023.10.31.4
           name: travel-authorization
           ports:
             - containerPort: 3000

--- a/manifests/test/deployment.yaml
+++ b/manifests/test/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: travel-authorization-tst
     spec:
       containers:
-        - image: harbor.ynet.gov.yk.ca/yg-github/ytgov/travel-authorization:v2023.10.13.1
+        - image: harbor.ynet.gov.yk.ca/yg-github/ytgov/travel-authorization:v2023.10.31.4
           name: travel-authorization
           ports:
             - containerPort: 3000

--- a/web/package.json
+++ b/web/package.json
@@ -5,8 +5,6 @@
   "scripts": {
     "start": "vue-cli-service serve",
     "build": "vue-cli-service build",
-    "build:web": "vue-cli-service build",
-    "build:docker": "vue-cli-service build",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -14,6 +14,7 @@ import "@/filters"
 import Notifications from "@/components/Notifications"
 import MapDialog from "@/components/MapDialog"
 
+import { environment, apiBaseUrl } from "@/config"
 
 Vue.use(VueApexCharts)
 
@@ -55,3 +56,5 @@ new Vue({
   i18n,
   render: (h) => h(App),
 }).$mount("#app")
+
+console.log("App is running config", { environment, apiBaseUrl })


### PR DESCRIPTION
# Context

I was building the front-end in development because I copied the config from another project.
This was working just find when testing the build locally because the default api base URL, happens to match what is required when running locally. In production it's incorrect.

I've also updated the manifest tag to see if it will auto-deploy the latest version.