### PR TITLE
Fixup: Take 2: Front-end Build Environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ COPY api ./
 
 RUN npm run build
 
-# Stage 2 - web build
+# Stage 2 - web build - requires development environment to install vue-cli-service
 FROM base-node as web-build-stage
 
-ENV NODE_ENV=production
+ENV NODE_ENV=development
 
 WORKDIR /usr/src/web
 
@@ -32,7 +32,8 @@ RUN npm install
 
 COPY web ./
 
-RUN npm run build
+# Switching to production mode for build environment.
+RUN NODE_ENV=production npm run build
 
 # Stage 3 - production setup
 FROM base-node

--- a/manifests/dev/deployment.yaml
+++ b/manifests/dev/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: travel-authorization-dev
     spec:
       containers:
-        - image: harbor.ynet.gov.yk.ca/yg-github/ytgov/travel-authorization:v2023.10.31.4
+        - image: harbor.ynet.gov.yk.ca/yg-github/ytgov/travel-authorization:v2023.10.31.5
           name: travel-authorization
           ports:
             - containerPort: 3000

--- a/manifests/test/deployment.yaml
+++ b/manifests/test/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: travel-authorization-tst
     spec:
       containers:
-        - image: harbor.ynet.gov.yk.ca/yg-github/ytgov/travel-authorization:v2023.10.31.4
+        - image: harbor.ynet.gov.yk.ca/yg-github/ytgov/travel-authorization:v2023.10.31.5
           name: travel-authorization
           ports:
             - containerPort: 3000


### PR DESCRIPTION
# Context

Install development dependencies to build front-end, but perform the build in production mode.
This makes vue-cli-service handle config based on node env. Probably we should just use a different technique to set the api base url.