### PR TITLE
Fixup: Boot Script Pathing After Spliting Index Into App and Server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,7 @@ COPY --from=api-build-stage --chown=node:node /usr/src/api/package*.json ./
 RUN npm install && npm cache clean --force --loglevel=error
 
 COPY --from=api-build-stage --chown=node:node /usr/src/api/dist ./dist
-COPY --from=web-build-stage --chown=node:node /usr/src/web/dist ./dist/web
+COPY --from=web-build-stage --chown=node:node /usr/src/web/dist ./dist/src/web
 
 EXPOSE 3000
 

--- a/api/bin/boot-app.sh
+++ b/api/bin/boot-app.sh
@@ -5,12 +5,12 @@ if [ "$NODE_ENV" != "production" ]; then
   npm run ts-node -- --files src/initializers/index.ts
 else
   # Run initializers in production
-  node ./dist/initializers/index.js
+  node ./dist/src/initializers/index.js
 fi
 
 # Start the application
 if [ "$NODE_ENV" != "production" ]; then
   npm run start
 else
-  node ./dist/server.js
+  node ./dist/src/server.js
 fi

--- a/api/package.json
+++ b/api/package.json
@@ -4,7 +4,7 @@
   "description": "API for YHSI Application",
   "main": "src/server.js",
   "scripts": {
-    "build": "tsc && tsc-alias",
+    "build": "tsc && tsc-alias && cp src/data/seeds/*.csv dist/src/data/seeds/",
     "start": "ts-node-dev -r tsconfig-paths/register src/server.ts",
     "ts-node": "ts-node -r tsconfig-paths/register",
     "knex": "ts-node -r tsconfig-paths/register ./node_modules/.bin/knex --knexfile src/config.d/knexfile.ts",


### PR DESCRIPTION
Relates to:

- https://github.com/ytgov/travel-authorization/pull/68

# Context

1. Fixes bug in app boot where /dist/index.js because /dist/src/server.js.
    I'm not sure why the original path wasn't /dist/src/index.js, I can only assume some magic was a work flattening the folder structure?
2. Fix the fact that seeds .csv files were not copied as part of the build process.
3. Fix web/index.html pathing as well. I'm not sure how it was working before? The magic of index.js I guess?

# Testing Instructions

1. Boot the app via `docker compose up --build`
2. Log in to the app at http://localhost:3000/
3. Check that you can go to the "My Travel Requests" page via the top drop down nav, and that it has some content.
